### PR TITLE
feat(board): record and clear indices of completed rows

### DIFF
--- a/src/models/Board.test.ts
+++ b/src/models/Board.test.ts
@@ -345,6 +345,214 @@ describe('Board', () => {
       expect(board.grid).toStrictEqual(expectedGrid);
     });
 
+    type CompletedRowsTestCase = [
+      name: string,
+      tetrominoInfo: {
+        blockOffsets: BlockPositions;
+        pivotPosition: Position;
+      },
+      gridInfo: {
+        grid: Cell[][];
+        bufferRowCount: number;
+      },
+      expectedCompletedRowIndices: number[]
+    ];
+
+    it.each<CompletedRowsTestCase>([
+      [
+        '1',
+        {
+          /**
+           *  Tetromino:
+           *   B
+           *   B B B
+           */
+          blockOffsets: [
+            [-1, -1],
+            [0, -1],
+            [0, 0],
+            [0, 1],
+          ],
+          pivotPosition: [3 + BUFFER_ROW_COUNT, 4],
+        },
+        {
+          grid: stringToGrid(
+            `
+              . . . . . . . . . .
+              . . . . . . . . . .
+              . P . . . . . . . .
+              P P P . . . P P P P
+              . W W . . G . . . W
+              W W w . G G . . W W
+            `,
+            BUFFER_ROW_COUNT
+          ),
+          bufferRowCount: BUFFER_ROW_COUNT,
+        },
+        [3 + BUFFER_ROW_COUNT],
+      ],
+      [
+        '2',
+        {
+          /**
+           *  Tetromino:
+           *   B B
+           *   B
+           *   B
+           */
+          blockOffsets: [
+            [-1, 0],
+            [-1, 1],
+            [0, 0],
+            [1, 0],
+          ],
+          pivotPosition: [3 + BUFFER_ROW_COUNT, 7],
+        },
+        {
+          grid: stringToGrid(
+            `
+              . . . . . . . . . .
+              . P B . . . . . . .
+              P P B B B N N . . W
+              P W W . N N . . . W
+              P W W G G G Y . W W
+              P W w G G . Y W W W
+            `,
+            BUFFER_ROW_COUNT
+          ),
+          bufferRowCount: BUFFER_ROW_COUNT,
+        },
+        [2 + BUFFER_ROW_COUNT, 4 + BUFFER_ROW_COUNT],
+      ],
+      [
+        '3',
+        {
+          /**
+           *  Tetromino:
+           *   B
+           *   B
+           *   B
+           *   B
+           */
+          blockOffsets: [
+            [-2, 0],
+            [-1, 0],
+            [0, 0],
+            [1, 0],
+          ],
+          pivotPosition: [4 + BUFFER_ROW_COUNT, 7],
+        },
+        {
+          grid: stringToGrid(
+            `
+              . W . . . . . . . .
+              . W W W . . . . . .
+              P P B B B N N . G G
+              P P B B B N N . G W
+              P W W . B B . . G W
+              P W W G G G Y . W W
+              P W w G G . Y W W W
+            `,
+            BUFFER_ROW_COUNT
+          ),
+          bufferRowCount: BUFFER_ROW_COUNT,
+        },
+        [2 + BUFFER_ROW_COUNT, 3 + BUFFER_ROW_COUNT, 5 + BUFFER_ROW_COUNT],
+      ],
+      [
+        '4',
+        {
+          /**
+           *  Tetromino:
+           *   B
+           *   B
+           *   B
+           *   B
+           */
+          blockOffsets: [
+            [-2, 0],
+            [-1, 0],
+            [0, 0],
+            [1, 0],
+          ],
+          pivotPosition: [4 + BUFFER_ROW_COUNT, 4],
+        },
+        {
+          grid: stringToGrid(
+            `
+              . W . . . . . . . .
+              . W W W . . W W W .
+              P P B B . N N W G G
+              P P B B . N P P G W
+              P W W G . N N P G W
+              P W W G . G G P W W
+              P W w G G G . W W W
+            `,
+            BUFFER_ROW_COUNT
+          ),
+          bufferRowCount: BUFFER_ROW_COUNT,
+        },
+        [
+          2 + BUFFER_ROW_COUNT,
+          3 + BUFFER_ROW_COUNT,
+          4 + BUFFER_ROW_COUNT,
+          5 + BUFFER_ROW_COUNT,
+        ],
+      ],
+    ])(
+      'finds all %s completed rows and records their indices',
+      (_, tetrominoInfo, gridInfo, expectedCompletedRowIndices) => {
+        const board = Board.fromGrid(gridInfo.grid, gridInfo.bufferRowCount);
+        const tetromino: TetrominoLike = {
+          color: Colors.BLUE,
+          getBlockPositions: mockGetBlockPosition(
+            tetrominoInfo.blockOffsets,
+            tetrominoInfo.pivotPosition
+          ),
+        };
+
+        board.lockTetromino(tetromino);
+        expect([...board.completedRowIndices]).toEqual(
+          expect.arrayContaining(expectedCompletedRowIndices)
+        );
+      }
+    );
+
+    it('does not record any row indices when no rows are completed', () => {
+      const grid = stringToGrid(
+        `
+          . . . . . . . . . .
+          . . . . . . . . . .
+          N N N N P P P . . W
+          N N N N R R R . . W
+          G . B B P P P . . W
+        `,
+        BUFFER_ROW_COUNT
+      );
+      const board = Board.fromGrid(grid, BUFFER_ROW_COUNT);
+      /**
+       *  Tetromino:
+       *     B
+       *     B
+       *   B B
+       */
+      const tetromino: TetrominoLike = {
+        color: Colors.BLUE,
+        getBlockPositions: mockGetBlockPosition(
+          [
+            [-1, 0],
+            [0, 0],
+            [1, -1],
+            [1, 0],
+          ],
+          [3 + BUFFER_ROW_COUNT, 8]
+        ),
+      };
+
+      board.lockTetromino(tetromino);
+      expect(board.completedRowIndices).toHaveLength(0);
+    });
+
     it('throws an error if the tetromino is not resting on the bottom or other blocks', () => {
       const totalRowCount = 20 + BUFFER_ROW_COUNT;
       const columnCount = 10;

--- a/src/models/Board.test.ts
+++ b/src/models/Board.test.ts
@@ -248,7 +248,7 @@ describe('Board', () => {
       }).toThrowError(RangeError);
     });
 
-    it('throws an error if the grid contains any completed lines', () => {
+    it('throws an error if the grid contains any completed rows', () => {
       const grid = stringToGrid(
         `
           . . . . . . . . . .
@@ -897,7 +897,7 @@ describe('Board', () => {
       expect(board.grid).toStrictEqual(expectedGrid);
     });
 
-    it('clears multiple completed rows separated by incomplete lines and shifts all the incomplete rows correctly down', () => {
+    it('clears multiple completed rows separated by incomplete rows and shifts all the incomplete rows correctly down', () => {
       const grid = stringToGrid(
         `
           . . . . . . . . . .

--- a/src/models/Board.test.ts
+++ b/src/models/Board.test.ts
@@ -268,8 +268,8 @@ describe('Board', () => {
     });
   });
 
-  describe('integrateLockedTetromino', () => {
-    it('integrates the locked tetromino correctly into an empty grid', () => {
+  describe('lockTetromino', () => {
+    it('integrates the tetromino correctly into an empty grid', () => {
       const totalRowCount = 5 + BUFFER_ROW_COUNT;
       const columnCount = 5;
       const board = Board.createEmpty(
@@ -289,7 +289,6 @@ describe('Board', () => {
       );
       const tetromino: TetrominoLike = {
         color: Colors.BLUE,
-        isLocked: true,
         getBlockPositions: mockGetBlockPosition(
           [
             [-1, 1],
@@ -301,11 +300,11 @@ describe('Board', () => {
         ),
       };
 
-      board.integrateLockedTetromino(tetromino);
+      board.lockTetromino(tetromino);
       expect(board.grid).toStrictEqual(expectedGrid);
     });
 
-    it('integrates the locked tetromino correctly into a non-empty grid', () => {
+    it('integrates the tetromino correctly into a non-empty grid', () => {
       const initialGrid = stringToGrid(
         `
               . . . . . . . . . .
@@ -331,7 +330,6 @@ describe('Board', () => {
       );
       const tetromino: TetrominoLike = {
         color: Colors.GREEN,
-        isLocked: true,
         getBlockPositions: mockGetBlockPosition(
           [
             [-1, 0],
@@ -343,44 +341,11 @@ describe('Board', () => {
         ),
       };
 
-      board.integrateLockedTetromino(tetromino);
+      board.lockTetromino(tetromino);
       expect(board.grid).toStrictEqual(expectedGrid);
     });
 
-    it('throws an error when the tetromino to be integrated is not locked', () => {
-      const totalRowCount = 5 + BUFFER_ROW_COUNT;
-      const columnCount = 5;
-      const board = Board.createEmpty(
-        totalRowCount,
-        columnCount,
-        BUFFER_ROW_COUNT
-      );
-      /**
-       *  Locked tetromino:
-       *     B
-       *   B B
-       *   B
-       */
-      const tetromino: TetrominoLike = {
-        color: Colors.BLUE,
-        isLocked: false,
-        getBlockPositions: mockGetBlockPosition(
-          [
-            [-1, 1],
-            [0, 0],
-            [0, 1],
-            [1, 0],
-          ],
-          [totalRowCount - 2, 0]
-        ),
-      };
-
-      expect(() => {
-        board.integrateLockedTetromino(tetromino);
-      }).toThrowError();
-    });
-
-    it('throws an error if the locked tetromino is not resting on the bottom or other blocks', () => {
+    it('throws an error if the tetromino is not resting on the bottom or other blocks', () => {
       const totalRowCount = 20 + BUFFER_ROW_COUNT;
       const columnCount = 10;
       const board = Board.createEmpty(
@@ -389,15 +354,13 @@ describe('Board', () => {
         BUFFER_ROW_COUNT
       );
       /**
-       *  Locked tetromino:
-       *
+       * Tetromino:
        *  B B
        *  B
        *  B
        */
       const tetromino: TetrominoLike = {
         color: Colors.BLUE,
-        isLocked: true,
         getBlockPositions: mockGetBlockPosition(
           [
             [-1, 0],
@@ -410,11 +373,11 @@ describe('Board', () => {
       };
 
       expect(() => {
-        board.integrateLockedTetromino(tetromino);
+        board.lockTetromino(tetromino);
       }).toThrowError();
     });
 
-    it('throws an error when any part of the locked tetromino is in the buffer rows', () => {
+    it('throws an error when any part of the tetromino is in the buffer rows', () => {
       const initialGrid = stringToGrid(
         `
           . . . . . . . . . .
@@ -428,7 +391,7 @@ describe('Board', () => {
       );
       const board = Board.fromGrid(initialGrid, BUFFER_ROW_COUNT);
       /**
-       *  Locked tetromino and its position on the grid:
+       *  Tetromino and its position on the grid:
        *    . . . . . . . . . .  buffer row
        *    . . . . . . . B . .  buffer row
        *    . . . . . . . B B .
@@ -440,7 +403,6 @@ describe('Board', () => {
        */
       const tetromino: TetrominoLike = {
         color: Colors.BLUE,
-        isLocked: true,
         getBlockPositions: mockGetBlockPosition(
           [
             [-1, 1],
@@ -453,7 +415,7 @@ describe('Board', () => {
       };
 
       expect(() => {
-        board.integrateLockedTetromino(tetromino);
+        board.lockTetromino(tetromino);
       }).toThrowError();
     });
 
@@ -560,7 +522,7 @@ describe('Board', () => {
         },
       ],
     ])(
-      'throws an error when the locked tetromino exceeds %s',
+      'throws an error when the tetromino exceeds %s',
       (_, tetrominoInfo, gridInfo) => {
         const { totalRowCount, columnCount, bufferRowCount } = gridInfo;
         const board = Board.createEmpty(
@@ -571,12 +533,11 @@ describe('Board', () => {
         const { blockOffsets, pivotPosition } = tetrominoInfo;
         const tetromino: TetrominoLike = {
           color: Colors.BLUE,
-          isLocked: true,
           getBlockPositions: mockGetBlockPosition(blockOffsets, pivotPosition),
         };
 
         expect(() => {
-          board.integrateLockedTetromino(tetromino);
+          board.lockTetromino(tetromino);
         }).toThrowError(/tetromino/);
       }
     );
@@ -720,18 +681,17 @@ describe('Board', () => {
         },
       ],
     ])(
-      'throws an error when the locked tetromino overlaps with filled cells %s',
+      'throws an error when the tetromino overlaps with filled cells %s',
       (_, tetrominoInfo, gridInfo) => {
         const board = Board.fromGrid(gridInfo.grid, gridInfo.bufferRowCount);
         const { blockOffsets, pivotPosition } = tetrominoInfo;
         const tetromino: TetrominoLike = {
           color: Colors.BLUE,
-          isLocked: true,
           getBlockPositions: mockGetBlockPosition(blockOffsets, pivotPosition),
         };
 
         expect(() => {
-          board.integrateLockedTetromino(tetromino);
+          board.lockTetromino(tetromino);
         }).toThrowError();
       }
     );
@@ -751,12 +711,11 @@ describe('Board', () => {
       );
       const board = Board.fromGrid(grid, BUFFER_ROW_COUNT);
       /**
-       *  Locked tetromino:
+       *  Tetromino:
        *   B B
        *   B B
        */
       const tetromino: TetrominoLike = {
-        isLocked: true,
         color: Colors.BLUE,
         getBlockPositions: mockGetBlockPosition(
           [
@@ -779,7 +738,7 @@ describe('Board', () => {
         BUFFER_ROW_COUNT
       );
 
-      board.integrateLockedTetromino(tetromino);
+      board.lockTetromino(tetromino);
       board.clearCompletedRows();
       expect(board.grid).toStrictEqual(expectedGrid);
     });
@@ -797,13 +756,12 @@ describe('Board', () => {
       );
       const board = Board.fromGrid(grid, BUFFER_ROW_COUNT);
       /**
-       *  Locked tetromino:
+       *  Tetromino:
        *   B B
        *     B
        * v   B
        */
       const tetromino: TetrominoLike = {
-        isLocked: true,
         color: Colors.BLUE,
         getBlockPositions: mockGetBlockPosition(
           [
@@ -826,7 +784,7 @@ describe('Board', () => {
         BUFFER_ROW_COUNT
       );
 
-      board.integrateLockedTetromino(tetromino);
+      board.lockTetromino(tetromino);
       board.clearCompletedRows();
       expect(board.grid).toStrictEqual(expectedGrid);
     });
@@ -845,14 +803,13 @@ describe('Board', () => {
       );
       const board = Board.fromGrid(grid, BUFFER_ROW_COUNT);
       /**
-       *  Locked tetromino:
+       *  Tetromino:
        *   B
        *   B
        *   B
        *   B
        */
       const tetromino: TetrominoLike = {
-        isLocked: true,
         color: Colors.BLUE,
         getBlockPositions: mockGetBlockPosition(
           [
@@ -876,7 +833,7 @@ describe('Board', () => {
         BUFFER_ROW_COUNT
       );
 
-      board.integrateLockedTetromino(tetromino);
+      board.lockTetromino(tetromino);
       board.clearCompletedRows();
       expect(board.grid).toStrictEqual(expectedGrid);
     });
@@ -900,14 +857,13 @@ describe('Board', () => {
       );
       const board = Board.fromGrid(grid, BUFFER_ROW_COUNT);
       /**
-       *  Locked tetromino:
+       *  Tetromino:
        *   B
        *   B
        *   B
        *   B
        */
       const tetromino: TetrominoLike = {
-        isLocked: true,
         color: Colors.BLUE,
         getBlockPositions: mockGetBlockPosition(
           [
@@ -936,7 +892,7 @@ describe('Board', () => {
         BUFFER_ROW_COUNT
       );
 
-      board.integrateLockedTetromino(tetromino);
+      board.lockTetromino(tetromino);
       board.clearCompletedRows();
       expect(board.grid).toStrictEqual(expectedGrid);
     });
@@ -962,14 +918,13 @@ describe('Board', () => {
       );
       const board = Board.fromGrid(grid, BUFFER_ROW_COUNT);
       /**
-       *  Locked tetromino:
+       *  Tetromino:
        *   N
        *   N
        *   N
        *   N
        */
       const tetromino: TetrominoLike = {
-        isLocked: true,
         color: Colors.NAVY,
         getBlockPositions: mockGetBlockPosition(
           [
@@ -1000,7 +955,7 @@ describe('Board', () => {
         BUFFER_ROW_COUNT
       );
 
-      board.integrateLockedTetromino(tetromino);
+      board.lockTetromino(tetromino);
       board.clearCompletedRows();
       expect(board.grid).toStrictEqual(expectedGrid);
     });

--- a/src/models/Board.test.ts
+++ b/src/models/Board.test.ts
@@ -1167,6 +1167,43 @@ describe('Board', () => {
       board.clearCompletedRows();
       expect(board.grid).toStrictEqual(expectedGrid);
     });
+
+    it('removes all entries from `completedRowIndices`', () => {
+      const grid = stringToGrid(
+        `
+          . . . . . . . . . .
+          . P B . . . . . . .
+          P P B B B N N . . W
+          P W W . N N . . . W
+          P W W G G G Y . W W
+          P W w G G . Y W W W
+        `,
+        BUFFER_ROW_COUNT
+      );
+      const board = Board.fromGrid(grid, BUFFER_ROW_COUNT);
+      /**
+       *  Tetromino:
+       *   B B
+       *   B
+       *   B
+       */
+      const tetromino: TetrominoLike = {
+        color: Colors.BLUE,
+        getBlockPositions: mockGetBlockPosition(
+          [
+            [-1, 0],
+            [-1, 1],
+            [0, 0],
+            [1, 0],
+          ],
+          [3 + BUFFER_ROW_COUNT, 7]
+        ),
+      };
+
+      board.lockTetromino(tetromino);
+      board.clearCompletedRows();
+      expect(board.completedRowIndices).toHaveLength(0);
+    });
   });
 });
 

--- a/src/models/Board.test.ts
+++ b/src/models/Board.test.ts
@@ -737,8 +737,8 @@ describe('Board', () => {
     );
   });
 
-  describe('clearLines', () => {
-    it('clears a single complete line', () => {
+  describe('clearCompletedRows', () => {
+    it('clears a single completed row', () => {
       const grid = stringToGrid(
         `
           . . . . . . . . . .
@@ -778,15 +778,13 @@ describe('Board', () => {
         `,
         BUFFER_ROW_COUNT
       );
-      const expectedLineClearCount = 1;
 
       board.integrateLockedTetromino(tetromino);
-      const lineClearCount = board.clearLines();
-      expect(lineClearCount).toBe(expectedLineClearCount);
+      board.clearCompletedRows();
       expect(board.grid).toStrictEqual(expectedGrid);
     });
 
-    it('clears multiple continuous complete lines', () => {
+    it('clears multiple continuous completed rows', () => {
       const grid = stringToGrid(
         `
           . . . . . . . . . .
@@ -827,15 +825,13 @@ describe('Board', () => {
         `,
         BUFFER_ROW_COUNT
       );
-      const expectedLineClearCount = 3;
 
       board.integrateLockedTetromino(tetromino);
-      const lineClearCount = board.clearLines();
-      expect(lineClearCount).toBe(expectedLineClearCount);
+      board.clearCompletedRows();
       expect(board.grid).toStrictEqual(expectedGrid);
     });
 
-    it('clears a single complete line and shifts the above rows down', () => {
+    it('clears a single completed row and shifts the above rows down', () => {
       const grid = stringToGrid(
         `
           . . . . . . . . . 
@@ -879,15 +875,13 @@ describe('Board', () => {
         `,
         BUFFER_ROW_COUNT
       );
-      const expectedLineClearCount = 1;
 
       board.integrateLockedTetromino(tetromino);
-      const lineClearCount = board.clearLines();
-      expect(lineClearCount).toBe(expectedLineClearCount);
+      board.clearCompletedRows();
       expect(board.grid).toStrictEqual(expectedGrid);
     });
 
-    it('clears multiple continuous complete lines and shifts the above rows down', () => {
+    it('clears multiple continuous completed rows and shifts the above rows down', () => {
       const grid = stringToGrid(
         `
           . . . . . . . . . .
@@ -941,15 +935,13 @@ describe('Board', () => {
         `,
         BUFFER_ROW_COUNT
       );
-      const expectedLineClearCount = 3;
 
       board.integrateLockedTetromino(tetromino);
-      const lineClearCount = board.clearLines();
-      expect(lineClearCount).toBe(expectedLineClearCount);
+      board.clearCompletedRows();
       expect(board.grid).toStrictEqual(expectedGrid);
     });
 
-    it('clears multiple complete lines separated by incomplete lines and shifts all the incomplete rows correctly down', () => {
+    it('clears multiple completed rows separated by incomplete lines and shifts all the incomplete rows correctly down', () => {
       const grid = stringToGrid(
         `
           . . . . . . . . . .
@@ -1007,11 +999,9 @@ describe('Board', () => {
         `,
         BUFFER_ROW_COUNT
       );
-      const expectedLineClearCount = 2;
 
       board.integrateLockedTetromino(tetromino);
-      const lineClearCount = board.clearLines();
-      expect(lineClearCount).toBe(expectedLineClearCount);
+      board.clearCompletedRows();
       expect(board.grid).toStrictEqual(expectedGrid);
     });
   });

--- a/src/models/Board.ts
+++ b/src/models/Board.ts
@@ -6,10 +6,7 @@ export interface Cell {
   color: string;
 }
 
-export type TetrominoLike = Pick<
-  Tetromino,
-  'getBlockPositions' | 'isLocked' | 'color'
->;
+export type TetrominoLike = Pick<Tetromino, 'getBlockPositions' | 'color'>;
 
 export class Board {
   #grid: Cell[][];
@@ -101,11 +98,7 @@ export class Board {
     return new Board(grid, bufferRowCount);
   }
 
-  integrateLockedTetromino(tetromino: TetrominoLike): void {
-    if (!tetromino.isLocked) {
-      throw new Error('The tetromino must be locked.');
-    }
-
+  lockTetromino(tetromino: TetrominoLike): void {
     const blocks = tetromino.getBlockPositions();
     let isFloating = true;
 

--- a/src/models/Board.ts
+++ b/src/models/Board.ts
@@ -16,12 +16,14 @@ export class Board {
   readonly #totalRowCount: number;
   readonly #columnCount: number;
   readonly #bufferRowCount: number;
+  #completedRowIndices: Set<number>;
 
   private constructor(grid: Cell[][], bufferRowCount: number) {
     this.#grid = grid;
     this.#totalRowCount = grid.length;
     this.#columnCount = grid[0].length;
     this.#bufferRowCount = bufferRowCount;
+    this.#completedRowIndices = new Set();
   }
 
   static createEmpty(
@@ -132,6 +134,16 @@ export class Board {
       this.#grid[i][j].filled = true;
       this.#grid[i][j].color = tetromino.color;
     }
+
+    this.#findAndRecordCompletedRows();
+  }
+
+  #findAndRecordCompletedRows(): void {
+    for (let i = this.#bufferRowCount; i < this.#totalRowCount; i++) {
+      if (this.#grid[i].every((col) => col.filled)) {
+        this.#completedRowIndices.add(i);
+      }
+    }
   }
 
   isValidPosition([i, j]: Position): boolean {
@@ -148,45 +160,49 @@ export class Board {
     return true;
   }
 
-  clearLines(): number {
-    const availableRowIndexQueue: number[] = [];
-    let clearedLineCount = 0;
+  clearCompletedRows(): void {
+    if (this.#completedRowIndices.size === 0) return;
 
-    for (let i = this.#totalRowCount - 1; i >= 0; i--) {
-      if (this.#grid[i].every((col) => col.filled)) {
-        clearedLineCount += 1;
-        availableRowIndexQueue.push(i);
+    const freedRowIndexQueue = [];
+
+    for (let i = this.#totalRowCount - 1; i >= this.#bufferRowCount; i--) {
+      if (this.#completedRowIndices.has(i)) {
+        freedRowIndexQueue.push(i);
 
         for (let j = 0; j < this.#columnCount; j++) {
           this.#grid[i][j].filled = false;
           this.#grid[i][j].color = '';
         }
+
         continue;
       }
 
-      const availableRowIndex = availableRowIndexQueue.shift();
-      if (availableRowIndex === undefined) continue;
+      const freedRowIndex = freedRowIndexQueue.shift();
+      if (freedRowIndex === undefined) continue;
 
       let emptyCellCount = 0;
-
       for (let j = 0; j < this.#columnCount; j++) {
         if (!this.#grid[i][j].filled) emptyCellCount++;
 
-        this.#grid[availableRowIndex][j].filled = this.#grid[i][j].filled;
-        this.#grid[availableRowIndex][j].color = this.#grid[i][j].color;
+        this.#grid[freedRowIndex][j].filled = this.#grid[i][j].filled;
+        this.#grid[freedRowIndex][j].color = this.#grid[i][j].color;
         this.#grid[i][j].filled = false;
         this.#grid[i][j].color = '';
       }
 
       if (emptyCellCount === this.#columnCount) break;
 
-      availableRowIndexQueue.push(i);
+      freedRowIndexQueue.push(i);
     }
 
-    return clearedLineCount;
+    this.#completedRowIndices.clear();
   }
 
   get grid(): readonly (readonly Readonly<Cell>[])[] {
     return this.#grid;
+  }
+
+  get completedRowIndices(): ReadonlySet<number> {
+    return this.#completedRowIndices;
   }
 }

--- a/src/models/Board.ts
+++ b/src/models/Board.ts
@@ -71,7 +71,7 @@ export class Board {
     }
 
     const columnCount = gridWithBufferRows[0].length;
-    const grid: Cell[][] = new Array(totalRowCount);
+    const grid: Cell[][] = Array.from({ length: totalRowCount });
 
     for (let i = 0; i < totalRowCount; i++) {
       if (gridWithBufferRows[i].length === 0) {
@@ -82,7 +82,7 @@ export class Board {
         throw new Error('All grid rows must have the same length.');
       }
 
-      grid[i] = new Array(columnCount);
+      grid[i] = Array.from({ length: columnCount });
       let filledCellCount = 0;
       for (let j = 0; j < columnCount; j++) {
         grid[i][j] = { ...gridWithBufferRows[i][j] };

--- a/src/models/Board.ts
+++ b/src/models/Board.ts
@@ -91,7 +91,7 @@ export class Board {
       }
 
       if (filledCellCount === columnCount) {
-        throw new Error('Grid should not contain any completed lines.');
+        throw new Error('Grid should not contain any completed rows.');
       }
     }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "target": "ES2020",
     "useDefineForClassFields": true,
     "module": "ESNext",
-    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "lib": ["ESNext", "DOM", "DOM.Iterable"],
     "skipLibCheck": true,
 
     /* Bundler mode */


### PR DESCRIPTION
This PR updates the `Board` class to record the indices of completed rows in `#completedRowIndices` when a tetromino is locked. These indices are cleared after the rows are removed. 